### PR TITLE
Add timestamps to Winston logger

### DIFF
--- a/backend/src/util/logger.ts
+++ b/backend/src/util/logger.ts
@@ -1,7 +1,12 @@
 import winston from 'winston';
-import { Logger } from 'winston';
+import { Logger, format } from 'winston';
+const { combine, timestamp } = format;
 
 const logger: Logger = winston.createLogger({
+    format: combine(
+        timestamp(),
+        format.json()
+    ),
     transports: [
         new winston.transports.Console({ level: process.env.NODE_ENV === 'production' ? 'info' : 'debug' }),
     ]


### PR DESCRIPTION
Log example:
`{"message":"Logging initialized at debug level","level":"debug","timestamp":"2020-07-10T15:55:35.143Z"}`